### PR TITLE
Add `getCurrentConfigurations`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-widget-center
 
-*Only supports iOS at the moment*
+_Only supports iOS at the moment_
 
 ## Getting started
 
@@ -13,12 +13,18 @@
 - Set WidgetKit.framework Status to Optional
 
 ## Usage
+
 ```javascript
-import RNWidgetCenter from 'react-native-widget-center';
+import RNWidgetCenter from "react-native-widget-center";
 
 // reload specific kind of widget (kind is specified in your WidgetConfiguration)
-RNWidgetCenter.reloadTimelines('my.widget.type');
+RNWidgetCenter.reloadTimelines("my.widget.type");
 
 // reload all widget timelines
 RNWidgetCenter.reloadAllTimelines();
+
+// get installed widgets configuration
+RNWidgetCenter.getCurrentConfigurations().then((result) => {
+  // do something
+});
 ```

--- a/index.js
+++ b/index.js
@@ -16,4 +16,10 @@ export default class WidgetCenter {
             RNWidgetCenter.reloadAllTimelines()
         }
     }
+
+    static getCurrentConfigurations = () => {
+        if (WidgetCenter.widgetCenterSupported) {
+            RNWidgetCenter.getCurrentConfigurations()
+        }
+    }
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ export default class WidgetCenter {
 
     static getCurrentConfigurations = () => {
         if (WidgetCenter.widgetCenterSupported) {
-            RNWidgetCenter.getCurrentConfigurations()
+            return RNWidgetCenter.getCurrentConfigurations()
         }
     }
 }

--- a/ios/RNWidgetCenter.m
+++ b/ios/RNWidgetCenter.m
@@ -6,4 +6,7 @@
 	
 	RCT_EXTERN_METHOD(reloadAllTimelines)
 
+    RCT_EXTERN_METHOD(getCurrentConfigurations:
+    (RCTPromiseResolveBlock)resolve
+    reject:(RCTPromiseRejectBlock)reject)
 @end

--- a/ios/RNWidgetCenter.swift
+++ b/ios/RNWidgetCenter.swift
@@ -29,4 +29,24 @@ class RNWidgetCenter: NSObject {
 		WidgetCenter.shared.reloadAllTimelines()
 		#endif
 	}
+
+    @objc(getCurrentConfigurations:reject:)
+    func getCurrentConfigurations (_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+        #if arch(arm64) || arch(x86_64)
+        WidgetCenter.shared.getCurrentConfigurations {result in
+            switch result {
+            case .success(let widgetInfo):
+                // Serialize widgets config into something the bridge understands
+                // https://reactnative.dev/docs/native-modules-ios#argument-types
+                var res:[[String: String]] = []
+                for widget in widgetInfo {
+                    res.append(["kind": widget.kind, "family": widget.family.description])
+                }
+                resolve(res)
+            case.failure(let error):
+                reject("404", "Couldn't get current widgets configuration", error)
+            }
+        }
+        #endif
+    }
 }


### PR DESCRIPTION
* Adds [WidgetCenter's getCurrentConfigurations](https://developer.apple.com/documentation/widgetkit/widgetcenter/getcurrentconfigurations(_:)) method to determine which widgets are installed
* On success, returns a promise containing an array of object with the widget `kind` and `family` keys

